### PR TITLE
Fix tag extraction to stop after first version match

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -19,7 +19,7 @@ jobs:
         id: "get-tag"
         shell: "bash"
         run: |
-          echo PKG_VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2) }' Cargo.toml) >> $GITHUB_OUTPUT
+          echo PKG_VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/["]/, "", $2); printf("%s",$2); exit; }' Cargo.toml) >> $GITHUB_OUTPUT
 
       - name: "Set Tag"
         shell: "bash"


### PR DESCRIPTION
Tag extraction did not work with multiple versions