### PR TITLE
Chore: Update versions and fix Dependabot.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "cargo" # See documentation for possible values
-    directory: "/src" # Location of package manifests
+    directory: "/" # Location of package manifests
     target-branch: "develop"
     schedule:
       interval: "weekly"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "PikchrMirror"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]
@@ -10,7 +10,7 @@ pretty_env_logger = "0.5.*"
 xml-rs = "0.8.*"
 
 [dependencies.resvg]
-version = "0.44.*"
+version = "0.45.*"
 
 [dependencies.floem]
 git = "https://github.com/lapce/floem"


### PR DESCRIPTION
Update dependency versions, especially pikchr 0.1.4 to support new syntax.
Fix wrong target directory for dependabot.